### PR TITLE
Add tuple binary vector in Hands

### DIFF
--- a/bridge_env/hands.py
+++ b/bridge_env/hands.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import random
 import re
-from typing import Dict, List, Set
+from typing import Dict, List, Set, Tuple
 
 import numpy as np
 
@@ -73,11 +73,25 @@ class Hands:
                  card.suit is suit]))
         return '.'.join(suits)
 
-    def to_binary(self, dtype: np.dtype = np.int) -> Dict[Player, np.ndarray]:
-        """Converts to 52 dims binary vectors.
+    def to_binary(self) -> Dict[Player, Tuple[int, ...]]:
+        """Converts to tuple of 52 dims binary vectors.
+
+        :return: Dict of Player and tuple of 52 dims binary vector.
+        """
+        binaries = dict()
+        for p in Player:
+            binary = [0] * 52
+            for card in self[p]:
+                binary[int(card)] = 1
+            binaries[p] = tuple(binary)
+        return binaries
+
+    def to_np_binary(self, dtype: np.dtype = np.int) -> Dict[
+        Player, np.ndarray]:
+        """Converts to 52 dims binary numpy array.
 
         :param dtype: numpy array's dtype.
-        :return: Dict of Player and 52 dims binary vector.
+        :return: Dict of Player and 52 dims binary numpy array.
         """
         binaries = dict()
         for p in Player:
@@ -98,11 +112,35 @@ class Hands:
 
     @classmethod
     def convert_binary(cls,
-                       binary_hands: Dict[Player, np.ndarray]) -> Hands:
-        """Converts dict of deal in binary vector format to Hands object.
+                       binary_hands: Dict[Player, Tuple[int, ...]]) -> Hands:
+        """Converts dict of deal in tuple of binary vector format to Hands object.
 
-        :param binary_hands: Dict of Player and deal of binary vectors.
-        :return: Hands instance converted from binary vectors.
+        :param binary_hands: Dict of Player and deal of tuple of binary vectors.
+        :return: Hands instance converted from tuple of binary vectors.
+        """
+        north = set()
+        east = set()
+        south = set()
+        west = set()
+        for i in range(52):
+            if binary_hands[Player.N][i] == 1:
+                north.add(Card.int_to_card(i))
+            elif binary_hands[Player.E][i] == 1:
+                east.add(Card.int_to_card(i))
+            elif binary_hands[Player.S][i] == 1:
+                south.add(Card.int_to_card(i))
+            elif binary_hands[Player.W][i] == 1:
+                west.add(Card.int_to_card(i))
+        return Hands(north_hand=north, east_hand=east,
+                     south_hand=south, west_hand=west)
+
+    @classmethod
+    def convert_np_binary(cls,
+                          binary_hands: Dict[Player, np.ndarray]) -> Hands:
+        """Converts dict of deal in binary numpy array format to Hands object.
+
+        :param binary_hands: Dict of Player and deal of binary numpy array.
+        :return: Hands instance converted from binary numpy array.
         """
         north_idxes = np.where(binary_hands[Player.N] == 1)[0]
         east_idxes = np.where(binary_hands[Player.E] == 1)[0]

--- a/tests/test_hands.py
+++ b/tests/test_hands.py
@@ -9,50 +9,53 @@ from tests.data_handler import HANDS1, HANDS2, HANDS3, PBN_HANDS1, PBN_HANDS2, \
 
 class TestHands:
     BINARY_HANDS1 = {
-        Player.N: np.array((0, 1, 1, 0, 0, 1, 0, 0, 0, 0, 1, 0, 1,
-                            1, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0,
-                            1, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0,
-                            0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)),
-        Player.E: np.array((1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                            0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 1,
-                            0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 1, 0, 0,
-                            0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0, 0)),
-        Player.S: np.array((0, 0, 0, 1, 0, 0, 1, 1, 1, 0, 0, 0, 0,
-                            0, 0, 0, 0, 1, 0, 0, 0, 1, 1, 0, 0, 0,
-                            0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0,
-                            1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 1)),
-        Player.W: np.array((0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 1, 0,
-                            0, 1, 0, 0, 0, 1, 0, 1, 0, 0, 1, 0, 0,
-                            0, 0, 1, 1, 0, 0, 0, 1, 0, 0, 0, 0, 1,
-                            0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0))}
+        Player.N: (0, 1, 1, 0, 0, 1, 0, 0, 0, 0, 1, 0, 1,
+                   1, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0,
+                   1, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0,
+                   0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+        Player.E: (1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                   0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 1,
+                   0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 1, 0, 0,
+                   0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0, 0),
+        Player.S: (0, 0, 0, 1, 0, 0, 1, 1, 1, 0, 0, 0, 0,
+                   0, 0, 0, 0, 1, 0, 0, 0, 1, 1, 0, 0, 0,
+                   0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0,
+                   1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 1),
+        Player.W: (0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 1, 0,
+                   0, 1, 0, 0, 0, 1, 0, 1, 0, 0, 1, 0, 0,
+                   0, 0, 1, 1, 0, 0, 0, 1, 0, 0, 0, 0, 1,
+                   0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0)}
     BINARY_HANDS2 = {
-        Player.N: np.array((1, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 1,
-                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0,
-                            0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 1, 0, 0,
-                            0, 1, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1)),
-        Player.E: np.array((0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                            1, 0, 1, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0,
-                            0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0,
-                            1, 0, 0, 1, 0, 1, 0, 1, 0, 0, 1, 1, 0)),
-        Player.S: np.array((0, 1, 0, 0, 0, 1, 1, 0, 0, 1, 0, 1, 0,
-                            0, 1, 0, 0, 0, 0, 0, 1, 1, 0, 1, 0, 0,
-                            0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1,
-                            0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0)),
-        Player.W: np.array((0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 1, 0, 0,
-                            0, 0, 0, 1, 1, 0, 0, 0, 0, 1, 0, 0, 1,
-                            1, 0, 0, 1, 0, 0, 1, 0, 1, 0, 0, 0, 0,
-                            0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0))}
+        Player.N: (1, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 1,
+                   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0,
+                   0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 1, 0, 0,
+                   0, 1, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1),
+        Player.E: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                   1, 0, 1, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0,
+                   0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0,
+                   1, 0, 0, 1, 0, 1, 0, 1, 0, 0, 1, 1, 0),
+        Player.S: (0, 1, 0, 0, 0, 1, 1, 0, 0, 1, 0, 1, 0,
+                   0, 1, 0, 0, 0, 0, 0, 1, 1, 0, 1, 0, 0,
+                   0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1,
+                   0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0),
+        Player.W: (0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 1, 0, 0,
+                   0, 0, 0, 1, 1, 0, 0, 0, 0, 1, 0, 0, 1,
+                   1, 0, 0, 1, 0, 0, 1, 0, 1, 0, 0, 0, 0,
+                   0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0)}
     BINARY_HANDS3 = {
-        Player.N: np.zeros(52),
-        Player.E: np.array((0, 0, 0, 0, 1, 0, 0, 0, 1, 1, 1, 0, 0,
-                            0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0,
-                            0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 1, 0,
-                            0, 0, 1, 1, 1, 0, 1, 0, 0, 0, 0, 0, 1)),
-        Player.S: np.zeros(52),
-        Player.W: np.array((0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0,
-                            1, 0, 1, 1, 1, 0, 0, 0, 0, 1, 0, 0, 0,
-                            0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1,
-                            1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 1, 0))}
+        Player.N: tuple([0] * 52),
+        Player.E: (0, 0, 0, 0, 1, 0, 0, 0, 1, 1, 1, 0, 0,
+                   0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0,
+                   0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 1, 0,
+                   0, 0, 1, 1, 1, 0, 1, 0, 0, 0, 0, 0, 1),
+        Player.S: tuple([0] * 52),
+        Player.W: (0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0,
+                   1, 0, 1, 1, 1, 0, 0, 0, 0, 1, 0, 0, 0,
+                   0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1,
+                   1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 1, 0)}
+    NP_BINARY_HANDS1 = {p: np.array(b) for p, b in BINARY_HANDS1.items()}
+    NP_BINARY_HANDS2 = {p: np.array(b) for p, b in BINARY_HANDS2.items()}
+    NP_BINARY_HANDS3 = {p: np.array(b) for p, b in BINARY_HANDS3.items()}
 
     @pytest.mark.parametrize(('hands', 'dealer', 'expected'),
                              [(HANDS1, Player.N, PBN_HANDS1),
@@ -70,6 +73,15 @@ class TestHands:
         for p in Player:
             np.testing.assert_array_equal(actual[p], expected[p])
 
+    @pytest.mark.parametrize(('hands', 'expected'),
+                             [(HANDS1, NP_BINARY_HANDS1),
+                              (HANDS2, NP_BINARY_HANDS2),
+                              (HANDS3, NP_BINARY_HANDS3)])
+    def test_to_np_binary(self, hands, expected):
+        actual = hands.to_np_binary()
+        for p in Player:
+            np.testing.assert_array_equal(actual[p], expected[p])
+
     @pytest.mark.parametrize(('pbn_hands', 'expected'),
                              [(PBN_HANDS1, HANDS1),
                               (PBN_HANDS2, HANDS2),
@@ -83,3 +95,10 @@ class TestHands:
                               (BINARY_HANDS3, HANDS3)])
     def test_convert_binary(self, binary_hands, expected):
         assert Hands.convert_binary(binary_hands) == expected
+
+    @pytest.mark.parametrize(('np_binary_hands', 'expected'),
+                             [(NP_BINARY_HANDS1, HANDS1),
+                              (NP_BINARY_HANDS2, HANDS2),
+                              (NP_BINARY_HANDS3, HANDS3)])
+    def test_convert_np_binary(self, np_binary_hands, expected):
+        assert Hands.convert_np_binary(np_binary_hands) == expected


### PR DESCRIPTION
Add not numpy array but tuple binary vector in Hands.

# Why
Conversion from numpy binary array to tuple binary vector takes time and needs conversion of numpy dtype such as `numpy.int64` to `int`.
