### PR TITLE
Implement a method to convert str to Contract object

### DIFF
--- a/bridge_env/contract.py
+++ b/bridge_env/contract.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import Optional
 
@@ -110,3 +112,25 @@ class Contract:
             "[Contract Bid], vul=[vulnerable], declarer=[declarer]"
         """
         return f'{self}, vul={self.vul}, declarer={self.declarer}'
+
+    @classmethod
+    def str_to_contract(cls,
+                        str_contract: str,
+                        vul: Vul = Vul.NONE,
+                        declarer: Optional[Player] = None) -> Contract:
+        if str_contract == 'Passed_out':
+            assert declarer is None
+            return Contract(final_bid=None, x=False, xx=False, vul=vul,
+                            declarer=declarer)
+
+        x = False
+        xx = False
+        if str_contract[-1] == 'X':
+            x = True
+            str_contract = str_contract[:-1]
+            if str_contract[-1] == 'X':
+                xx = True
+                str_contract = str_contract[:-1]
+
+        return Contract(final_bid=Bid.str_to_bid(str_contract), x=x, xx=xx,
+                        vul=vul, declarer=declarer)

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -45,3 +45,16 @@ class TestContract:
                               (CONTRACT_6S, True)])
     def test_is_vul(self, contract, expected):
         assert contract.is_vul() == expected
+
+    @pytest.mark.parametrize(('str_contract', 'vul', 'declarer', 'expected'), [
+        ('1CX', Vul.NONE, Player.N,
+         Contract(Bid.C1, x=True, vul=Vul.NONE, declarer=Player.N)),
+        ('3NT', Vul.NS, Player.E,
+         Contract(Bid.NT3, vul=Vul.NS, declarer=Player.E)),
+        ('5SXX', Vul.EW, Player.W,
+         Contract(Bid.S5, x=True, xx=True, vul=Vul.EW, declarer=Player.W)),
+        ('6NTXX', Vul.BOTH, Player.S,
+         Contract(Bid.NT6, x=True, xx=True, vul=Vul.BOTH, declarer=Player.S)),
+        ('Passed_out', Vul.EW, None, Contract(None, vul=Vul.EW, declarer=None))])
+    def test_str_to_contract(self, str_contract, vul, declarer, expected):
+        assert Contract.str_to_contract(str_contract, vul, declarer) == expected


### PR DESCRIPTION
Implement `str_to_contract` in Contract as a class method.