### PR TITLE
Replace `np.int` with `np.int32` to Resolve AttributeError in NumPy

### DIFF
--- a/bridge_env/hands.py
+++ b/bridge_env/hands.py
@@ -86,7 +86,7 @@ class Hands:
             binaries[p] = tuple(binary)
         return binaries
 
-    def to_np_binary(self, dtype: np.dtype = np.int) -> Dict[
+    def to_np_binary(self, dtype: np.dtype = np.int32) -> Dict[
         Player, np.ndarray]:
         """Converts to 52 dims binary numpy array.
 


### PR DESCRIPTION
Updated all instances of `np.int` to `np.int32` to fix an `AttributeError` in newer NumPy versions. This ensures compatibility following the deprecation of `np.int` in version 1.20.